### PR TITLE
Stop publishing releases

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -2,8 +2,8 @@ name: Generate Az ps module
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '*/5 * * * *'
+#   schedule:
+#     - cron: '0 0 */5 * *'
 
 defaults:
   run:


### PR DESCRIPTION
Stop publishing releases as it is not required in forked repos as it created unwanted notifications.